### PR TITLE
Fixed typographical error, changed accomodate to accommodate in README.

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -545,7 +545,7 @@ line to the next, as the following snippet shows:
      my_array.delete_at(0)
      puts my_array.rtc_type # prints "Array<String>"
 across these three lines (not counting the puts statement) the type
-changed twice. To accomodate this dynamic behavior, we say that a type
+changed twice. To accommodate this dynamic behavior, we say that a type
 parameter is either dynamic or fixed.  This is something of a abuse of
 terminology, at runtime, type parameters are substituted with type
 stand-ins, but that is an implementation detail and only confuses the


### PR DESCRIPTION
@plum-umd, I've corrected a typographical error in the documentation of the [rtc](https://github.com/plum-umd/rtc) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
